### PR TITLE
fix: Match the function component style

### DIFF
--- a/packages/typescript/libs/biome/configs/frameworks/react.json
+++ b/packages/typescript/libs/biome/configs/frameworks/react.json
@@ -32,7 +32,7 @@
             "useReactFunctionComponentDefinition": {
               "level": "error",
               "options": {
-                "namedComponents": "arrowFunction"
+                "namedComponents": "functionDeclaration"
               }
             }
           },


### PR DESCRIPTION
Closes #38. Components in the house style are function declarations with a bottom export, so `useReactFunctionComponentDefinition` now requires `functionDeclaration`.