### PR TITLE
fix: Pin the shared workflows to an exact release

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    uses: droneey/.github/.github/workflows/cd-deploy-npm.yml@v1
+    uses: droneey/.github/.github/workflows/cd-deploy-npm.yml@v1.4.0
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/cd-pre-release.yml
+++ b/.github/workflows/cd-pre-release.yml
@@ -6,8 +6,9 @@ on:
 
 jobs:
   pre-release:
-    uses: droneey/.github/.github/workflows/cd-pre-release.yml@v1
+    uses: droneey/.github/.github/workflows/cd-release.yml@v1.4.0
     permissions:
       contents: write
     with:
-      packages: "package.json packages/typescript/libs/*/package.json"
+      packages: package.json packages/typescript/libs/*/package.json
+      prerelease: true

--- a/.github/workflows/cd-version.yml
+++ b/.github/workflows/cd-version.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   version:
     if: "!startsWith(github.event.head_commit.message, 'chore: Release v')"
-    uses: droneey/.github/.github/workflows/cd-version.yml@v1
+    uses: droneey/.github/.github/workflows/cd-version.yml@v1.4.0
     permissions:
       contents: write
       pull-requests: read


### PR DESCRIPTION
Closes #42. Exact pins on droneey/.github v2.0.0: the version comes from tags, the four package.json files are updated through version-command, pre-release goes through cd-release with prerelease true.