### PR TITLE
fix: Move to the tag-based shared workflows

### DIFF
--- a/.github/workflows/cd-deploy.yml
+++ b/.github/workflows/cd-deploy.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   deploy:
-    uses: droneey/.github/.github/workflows/cd-deploy-npm.yml@v1.4.0
+    uses: droneey/.github/.github/workflows/cd-deploy-npm.yml@v2.0.0
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/cd-pre-release.yml
+++ b/.github/workflows/cd-pre-release.yml
@@ -6,9 +6,8 @@ on:
 
 jobs:
   pre-release:
-    uses: droneey/.github/.github/workflows/cd-release.yml@v1.4.0
+    uses: droneey/.github/.github/workflows/cd-release.yml@v2.0.0
     permissions:
       contents: write
     with:
-      packages: package.json packages/typescript/libs/*/package.json
       prerelease: true

--- a/.github/workflows/cd-version.yml
+++ b/.github/workflows/cd-version.yml
@@ -11,11 +11,14 @@ concurrency:
 jobs:
   version:
     if: "!startsWith(github.event.head_commit.message, 'chore: Release v')"
-    uses: droneey/.github/.github/workflows/cd-version.yml@v1.4.0
+    uses: droneey/.github/.github/workflows/cd-version.yml@v2.0.0
     permissions:
       contents: write
       pull-requests: read
     with:
-      packages: "package.json packages/typescript/libs/*/package.json"
+      version-command: |
+        for f in package.json packages/typescript/libs/*/package.json; do
+          jq --arg v "$VERSION" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+        done
     secrets:
       token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -52,3 +52,9 @@ jobs:
             echo "::error::Line coverage is $LINES%, expected 100%"
             exit 1
           fi
+
+      - name: ✅ Lint the workflows
+        run: |
+          set -euo pipefail
+          bash <(curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12 "${RUNNER_TEMP}"
+          "${RUNNER_TEMP}/actionlint" -color


### PR DESCRIPTION
Closes #44. Pins droneey/.github v2.0.0; the four package.json files are updated through version-command; pre-release goes through cd-release with prerelease true.