### PR TITLE
docs: Point the biome schema at the installed package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ bun add -d \
 ```json
 // biome.json
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": [
     "@droneey/devkit-ts-biome/base",
     "@droneey/devkit-ts-biome/node",

--- a/packages/typescript/libs/biome/README.md
+++ b/packages/typescript/libs/biome/README.md
@@ -12,7 +12,7 @@ Create `biome.json` in your project root:
 
 ```json
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.12/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "extends": ["@droneey/devkit-ts-biome/base"]
 }
 ```


### PR DESCRIPTION
Closes #46. The `$schema` example now references the schema shipped with the installed biome, so upgrades need no manual bump.